### PR TITLE
Implement saving of plant target values

### DIFF
--- a/Plantify new/plantify/app.py
+++ b/Plantify new/plantify/app.py
@@ -139,6 +139,27 @@ def plant_detail(slug):
     return render_template('plant.html', plant=plant, rooms=ROOMS,
                            trivial=plant['name'], botanisch=plant['name'])
 
+@app.route('/api/plant/<int:plant_id>', methods=['POST'])
+@login_required
+def update_plant_api(plant_id: int):
+    """Update plant data in the in-memory list."""
+    data = request.get_json(silent=True) or {}
+    plant = next((p for p in PLANTS if p['id'] == plant_id), None)
+    if not plant:
+        return jsonify({'error': 'Plant not found'}), 404
+    allowed = {
+        'facts',
+        'name',
+        'room',
+        'target_temperature',
+        'target_air_humidity',
+        'target_ground_humidity',
+    }
+    for key in allowed:
+        if key in data:
+            plant[key] = data[key]
+    return jsonify({'success': True})
+
 # Einstellungen
 @app.route('/settings')
 @login_required

--- a/Plantify new/plantify/templates/plant.html
+++ b/Plantify new/plantify/templates/plant.html
@@ -58,7 +58,6 @@ document.addEventListener('DOMContentLoaded', function () {
       const targetTemperature = document.getElementById('target-temperature').value;
       const targetAirHumidity = document.getElementById('target-air-humidity').value;
       const targetGroundHumidity = document.getElementById('target-ground-humidity').value;
-      // API entfernt – Daten werden lokal aktualisiert
       const data = {
         facts: facts,
         name: name,
@@ -67,6 +66,11 @@ document.addEventListener('DOMContentLoaded', function () {
         target_air_humidity: targetAirHumidity,
         target_ground_humidity: targetGroundHumidity
       };
+      await fetch('/api/plant/{{ plant.id }}', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
       const newSlug = name.toLowerCase().replace(/\s+/g, '-') + '-{{ plant.id }}';
       const currentSlug = window.location.pathname.split('/').pop();
       if (newSlug !== currentSlug) {

--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ This repository contains the Plantify project including a small Flask applicatio
 
 The chart is rendered in `templates/dashboard.html` using Chart.js and dummy measurement data in `static/dashboard.js`. Chart.js is loaded from a CDN.
 
+Plant details can be edited on the plant page. Changes are sent to the new
+`/api/plant/<id>` endpoint which updates the in-memory `PLANTS` list so that the
+"Schnellübersicht" reflects the saved target values after a reload.
+


### PR DESCRIPTION
## Summary
- allow persisting plant settings in-memory via `/api/plant/<id>`
- trigger API call from plant detail page when saving
- document new endpoint in README

## Testing
- `python -m py_compile 'Plantify new/plantify/app.py'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68656bc9b990832fa35e1ab6d96e1334