### PR TITLE
Remove unused MySQL connector

### DIFF
--- a/Plantify new/plantify/requirements.txt
+++ b/Plantify new/plantify/requirements.txt
@@ -1,4 +1,3 @@
 Flask==3.0.2
-mysql-connector-python==8.3.0
 Werkzeug==3.0.1
 bcrypt==4.1.2


### PR DESCRIPTION
## Summary
- remove `mysql-connector-python` dependency from requirements since no MySQL code exists

## Testing
- `python -m py_compile 'Plantify new/plantify/app.py'`

------
https://chatgpt.com/codex/tasks/task_e_68656e58129c832fb31a2628ab8f5fb9