### PR TITLE
Add email validation on registration and settings

### DIFF
--- a/Plantify new/plantify/app.py
+++ b/Plantify new/plantify/app.py
@@ -2,6 +2,7 @@ from flask import Flask, render_template, request, redirect, session, url_for, j
 from functools import wraps
 import os
 import bcrypt
+from email_validator import validate_email, EmailNotValidError
 
 
 app = Flask(__name__)
@@ -79,6 +80,16 @@ def inject_sidebar_data():
 
 def slugify(value: str) -> str:
     return value.lower().replace(" ", "-")
+
+def is_valid_email(email: str) -> bool:
+    """Validate an email address using the email-validator package."""
+    if not email:
+        return False
+    try:
+        validate_email(email)
+        return True
+    except EmailNotValidError:
+        return False
 
 # --- Login-Decorator für geschützte Seiten ---
 def login_required(f):
@@ -181,7 +192,7 @@ def settings():
 def change_email():
     new_email = request.form.get('new_email')
     current_email = session.get('user_id')
-    if new_email and current_email in USERS:
+    if new_email and is_valid_email(new_email) and current_email in USERS:
         USERS[new_email] = USERS.pop(current_email)
         session['user_id'] = new_email
         return redirect(url_for('settings', msg_email='success'))
@@ -212,6 +223,8 @@ def register():
 
         if not email or not password:
             return render_template('register.html', error='E-Mail und Passwort benötigt!')
+        if not is_valid_email(email):
+            return render_template('register.html', error='Ungültige E-Mail-Adresse!')
         if password != confirm:
             return render_template('register.html', error='Passwörter stimmen nicht überein!')
         if email in USERS:

--- a/Plantify new/plantify/requirements.txt
+++ b/Plantify new/plantify/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.2
 Werkzeug==3.0.1
 bcrypt==4.1.2
+email-validator==2.1.1


### PR DESCRIPTION
## Summary
- add `email-validator` dependency
- implement `is_valid_email` helper using email-validator
- use helper in `/register` and `/settings/change-email`

## Testing
- `python -m py_compile 'Plantify new'/plantify/app.py`
- `pip install -r 'Plantify new'/plantify/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68656fbd16cc832f89395402cf28ef2b