### PR TITLE
Add API graphs

### DIFF
--- a/Plantify new/plantify/static/plots.js
+++ b/Plantify new/plantify/static/plots.js
@@ -1,0 +1,43 @@
+// Load Plotly graphs and latest measurements from plantify_api
+
+function loadPlots(baseUrl) {
+    const potId = new URLSearchParams(window.location.search).get('pot_id') || '1';
+    const map = {
+        'plot-sun': 'sunlight',
+        'plot-temp': 'temperature',
+        'plot-soil': 'soil',
+        'plot-air': 'luftfeuchtigkeit'
+    };
+    Object.entries(map).forEach(([elementId, plot]) => {
+        const el = document.getElementById(elementId);
+        if (!el) return;
+        fetch(`${baseUrl}/plots/${plot}?pot_id=${potId}`)
+            .then(r => r.text())
+            .then(html => {
+                el.innerHTML = html;
+            })
+            .catch(err => console.error('Failed to load plot', plot, err));
+    });
+}
+
+function loadLatestValues(baseUrl) {
+    const rows = document.querySelectorAll('#care-guidelines tbody tr');
+    rows.forEach(row => {
+        const id = row.dataset.potId;
+        if (!id) return;
+        fetch(`${baseUrl}/latest-value?pot_id=${id}`)
+            .then(r => r.json())
+            .then(d => {
+                row.querySelector('.val-temp').textContent = parseFloat(d.temperature).toFixed(1);
+                row.querySelector('.val-air').textContent = parseFloat(d.air_humidity).toFixed(1);
+                row.querySelector('.val-soil').textContent = parseFloat(d.soil_moisture).toFixed(1);
+            })
+            .catch(err => console.error('Failed to load latest values', err));
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const apiBase = 'http://localhost:5001';
+    loadPlots(apiBase);
+    loadLatestValues(apiBase);
+});

--- a/Plantify new/plantify/templates/dashboard.html
+++ b/Plantify new/plantify/templates/dashboard.html
@@ -32,20 +32,19 @@
     <div class="card charts-card">
         <div class="chart-container">
             <h3>Sonnenstunden</h3>
-            <canvas id="chart-sun"></canvas>
+            <div id="plot-sun"></div>
         </div>
         <div class="chart-container">
             <h3>Temperatur Verlauf</h3>
-            <!-- Chart für Temperatur Verlauf -->
-            <canvas id="chart-temp"></canvas>
+            <div id="plot-temp"></div>
         </div>
         <div class="chart-container">
             <h3>Bodenfeuchtigkeit Verlauf</h3>
-            <canvas id="chart-soil"></canvas>
+            <div id="plot-soil"></div>
         </div>
         <div class="chart-container">
             <h3>Luftfeuchtigkeit Verlauf</h3>
-            <canvas id="chart-air"></canvas>
+            <div id="plot-air"></div>
         </div>
     </div>
 
@@ -61,8 +60,5 @@
     </div>
 </div>
 
-<!-- Chart.js für Diagramme -->
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script src="{{ url_for('static', filename='plant.js') }}"></script>
-<script src="{{ url_for('static', filename='dashboard.js') }}"></script>
+<script src="{{ url_for('static', filename='plots.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace dashboard canvas elements with plot placeholders
- fetch Plotly graphs and latest measurements from `plantify_api`

## Testing
- `python3 -m py_compile 'Plantify new/plantify/app.py'`

------
https://chatgpt.com/codex/tasks/task_e_6867d510356c832f98c8230f2098094d