### PR TITLE
Remove charts from dashboard

### DIFF
--- a/Plantify new/plantify/templates/dashboard.html
+++ b/Plantify new/plantify/templates/dashboard.html
@@ -29,24 +29,6 @@
         </table>
     </div>
 
-    <div class="card charts-card">
-        <div class="chart-container">
-            <h3>Sonnenstunden</h3>
-            <div id="plot-sun"></div>
-        </div>
-        <div class="chart-container">
-            <h3>Temperatur Verlauf</h3>
-            <div id="plot-temp"></div>
-        </div>
-        <div class="chart-container">
-            <h3>Bodenfeuchtigkeit Verlauf</h3>
-            <div id="plot-soil"></div>
-        </div>
-        <div class="chart-container">
-            <h3>Luftfeuchtigkeit Verlauf</h3>
-            <div id="plot-air"></div>
-        </div>
-    </div>
 
     <div class="card facts-card" id="facts-box">
         <h3>Pflanzen Fakten</h3>


### PR DESCRIPTION
## Summary
- remove charts from dashboard page

## Testing
- `python -m py_compile 'Plantify new/plantify/app.py'`

------
https://chatgpt.com/codex/tasks/task_e_686ccaf8a894832f9bee2bda6389dc43