### PR TITLE
Integrate plantify_api endpoints

### DIFF
--- a/Plantify new/plantify/requirements.txt
+++ b/Plantify new/plantify/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.2
 Werkzeug==3.0.1
 email-validator==2.1.1
+requests==2.31.0

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 This repository contains the Plantify project including a small Flask application and static frontend files. The dashboard integrates a temperature history chart for each room.
 
-Graphs on the dashboard are loaded from the API and embedded with Plotly via
-`static/plots.js`.
+Graphs on the dashboard are loaded from the separate `plantify_api` service and
+embedded with Plotly via `static/plots.js`.
 
-Plant details can be edited on the plant page. Changes are sent to the new
-`/api/plant/<id>` endpoint which updates the in-memory `PLANTS` list so that the
-"Schnellübersicht" reflects the saved target values after a reload.
+Plant and room data are now fetched from this API on each request. Edited plant
+details are stored temporarily via `/api/plant/<id>` so the "Schnellübersicht"
+reflects the changes after a reload.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- remove hard-coded dummy lists
- fetch plants and rooms from `plantify_api`
- implement login and settings changes via API calls
- keep plant edits temporarily in memory
- update requirements and docs

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d247038a8832f8091151bf5434e6d